### PR TITLE
Fix broken links on local builds

### DIFF
--- a/src/partials/body-home.hbs
+++ b/src/partials/body-home.hbs
@@ -9,7 +9,94 @@
   </div>
 <main data-ceiling="topbar">
 <article class="article">
-{{{page.contents}}}
+
+<div class="cards">
+
+<div class="card">
+	<h3 class="card-header cloud"><img src="{{{siteRootPath}}}/home/_images/cloud.svg">
+		 hazelcast
+	</h3>
+	<p class="card-summary">
+		Use Hazelcast as a managed service.
+	</p>
+	<ul>
+		<li class="get-started-home">
+			<a href="https://docs.cloud.hazelcast.com/docs/getting-started">Get Started <img src="{{{siteRootPath}}}/home/_images/right-arrow.svg"></a>
+		</li>
+	</ul>
+
+	<h3 class="card-header imdg"><img src="{{{siteRootPath}}}/home/_images/imdg.svg"></img>
+		 hazelcast
+	</h3>
+	<p class="card-summary">
+		Run a Hazelcast IMDG cluster.
+	</p>
+	<ul>
+		<li><a href="https://guides.hazelcast.org/home/">Tutorials</a></li>
+		<li><a href="https://hazelcast.com/resources/hazelcast-deployment-operations-guide/">Operations Guide</a></li>
+		<li class="get-started-home">
+			<a href="{{{siteRootPath}}}/imdg/latest/getting-started.html">Get Started <img src="{{{siteRootPath}}}/home/_images/right-arrow.svg"></a>
+		</li>
+	</ul>
+	
+	<h3 class="card-header jet"><img src="{{{siteRootPath}}}/home/_images/jet.svg">
+		 hazelcast
+	</h3>
+	<p class="card-summary">
+		Run stateful computations over data.
+	</p>
+	<ul>
+		<li><a href="https://jet-start.sh/docs/tutorials/kafka">Tutorials</a></li>
+		<li><a href="https://jet-start.sh/docs/operations/installation">Operations Guide</a></li>
+		<li class="get-started-home">
+			<a href="https://jet-start.sh/docs/get-started/intro">Get Started <img src="{{{siteRootPath}}}/home/_images/right-arrow.svg"></a>
+		</li>
+	</ul>
+</div>
+
+<div class="card">
+	<h3 class="card-header">
+		Management Center
+	</h3>
+	<p class="card-summary">
+		Monitor your Hazelcast clusters.
+	</p>
+	<ul>
+		<li class="get-started-home">
+			<a href="https://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html#deploying-and-starting">Get Started <img src="{{{siteRootPath}}}/home/_images/right-arrow.svg"></a>
+		</li>
+	</ul>
+
+	<h3 class="card-header">Hazelcast Clients
+	</h3>
+	<p class="card-summary">
+		Connect your applications to Hazelcast clusters.
+	</p>
+	<ul>
+		<li><a href="https://hazelcast.org/imdg/clients-languages/java/">Java (Client or Embedded)</a></li>
+		<li><a href="https://hazelcast.org/imdg/clients-languages/dotnet/">.Net</a></li>
+		<li><a href="https://hazelcast.org/imdg/clients-languages/cplusplus/">C++</a></li>
+		<li><a href="https://hazelcast.org/imdg/clients-languages/node-js/">Node.js</a></li>
+		<li><a href="https://hazelcast.org/imdg/clients-languages/python/">Python</a></li>
+		<li><a href="https://hazelcast.org/imdg/clients-languages/go/">Go</a></li>
+		<li><a href="https://docs.hazelcast.org/docs/latest/manual/html-single/index.html#rest-client">REST</a></li>
+		<li><a href="https://docs.hazelcast.org/docs/latest/manual/html-single/index.html#memcache-client">Memcache</a></li>
+	</ul>
+</div>
+
+<div class="card">
+	<h3 class="card-header">See Also
+	</h3>
+	<p class="card-summary">
+		Other helpful documentation resources.
+	</p>
+	<ul>
+		<li><a href="https://hazelcast.org/hub/">Integration Hub</a>Explore our connectors and plugins for integrating Hazelcast with various data systems, application frameworks, and cloud runtimes.</li>
+		<li><a href="https://training.hazelcast.com/">Online Training</a>Learn Hazelcast by following self-paced online training courses.</li>
+		<li><a href="https://hazelcast.com/resources/mastering-hazelcast/">Mastering Hazelcast eBook</a>Get in-depth knowledge of the important features of Hazelcast.</li>
+	</ul>
+</div>
+</div>
 </article>
 </main>
 </div>

--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -22,7 +22,7 @@
     </div>
     <div id="topbar-nav" class="navbar-menu">
       <div class="navbar-end">
-        <a class="navbar-item" href="https://jakescahill.github.io/hazelcast-docs/home/index.html">Home</a>
+        <a class="navbar-item" href="{{{siteRootPath}}}/home/index.html">Home</a>
         <div class="navbar-item has-dropdown is-hoverable">
           <a class="navbar-link" href="#">Products<img class="dropdown-caret" src="{{{uiRootPath}}}/img/caret-blue.svg"></img></a>
           <div class="navbar-dropdown">
@@ -34,7 +34,7 @@
         <div class="navbar-item has-dropdown is-hoverable">
           <a class="navbar-link" href="#">Learn<img class="dropdown-caret" src="{{{uiRootPath}}}/img/caret-blue.svg"></img></a>
           <div class="navbar-dropdown">
-            <a class="navbar-item" href="https://jakescahill.github.io/hazelcast-docs/home/index.html">Docs</a>
+            <a class="navbar-item" href="{{{siteRootPath}}}/home/index.html">Docs</a>
             <a class="navbar-item" href="https://training.hazelcast.com/" onclick="window.open(this.href,'_blank');return false;">Online Training</a>
             <a class="navbar-item" href="https://hazelcast.com/resources/mastering-hazelcast/" onclick="window.open(this.href,'_blank');return false;"> Mastering Hazelcast eBook</a>
             <a class="navbar-item" href="https://hazelcast.org/resources/" onclick="window.open(this.href,'_blank');return false;">Search All Resources</a>


### PR DESCRIPTION
Moved the home page markup from the `hazelcast-docs` repository to the `home-body.hbs` template to make links relative.