### PR TITLE
Update links to hazelcast repo

### DIFF
--- a/.github/CONTRIBUTING.adoc
+++ b/.github/CONTRIBUTING.adoc
@@ -1,7 +1,7 @@
 = Contributing to the Hazelcast Docs UI
-:url-imdg-docs: https://github.com/JakeSCahill/imdg-docs
-:url-docs-playbook: https://github.com/JakeSCahill/hazelcast-docs
-:url-docs-ui: https://github.com/JakeSCahill/hazelcast-docs-ui
+:url-imdg-docs: https://github.com/hazelcast/imdg-docs
+:url-docs-playbook: https://github.com/hazelcast/hazelcast-docs
+:url-docs-ui: https://github.com/hazelcast/hazelcast-docs-ui
 :url-hazelcast: https://hazelcast.com
 :url-antora: https://antora.org
 :url-git: https://git-scm.com

--- a/README.adoc
+++ b/README.adoc
@@ -4,7 +4,7 @@
 :hide-uri-scheme:
 // Project URLs:
 :url-docs: https://docs.hazelcast.com
-:url-docs-playbook: https://github.com/JakeSCahill/hazelcast-docs
+:url-docs-playbook: https://github.com/hazelcast/hazelcast-docs
 :url-contributing: .github/CONTRIBUTING.adoc
 :url-antora: https://antora.org
 :url-hazelcast: https://hazelcast.com

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "hazelcast-docs-ui",
   "description": "A modified version of the default Antora UI, which includes design components for the Hazelcast documentation site",
-  "homepage": "https://github.com/JakeSCahill/hazelcast-docs-ui",
+  "homepage": "https://github.com/hazelcast/hazelcast-docs-ui",
   "license": "MPL-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/JakeSCahill/hazelcast-docs-ui.git"
+    "url": "https://github.com/hazelcast/hazelcast-docs-ui.git"
   },
   "engines": {
     "node": ">= 8.0.0"

--- a/preview-src/ui-model.yml
+++ b/preview-src/ui-model.yml
@@ -35,7 +35,7 @@ page:
   displayVersion: '4.1'
   module: ROOT
   relativeSrcPath: java.adoc
-  editUrl: https://github.com/JakeSCahill/hazelcast-docs-ui/blob/master/preview-src/java.adoc
+  editUrl: https://github.com/hazelcast/hazelcast-docs-ui/blob/master/preview-src/java.adoc
   origin:
     private: false
   previous:


### PR DESCRIPTION
Updated GitHub links so that they don't break when we transfer ownerhip of this repository to the `hazelcast` organization